### PR TITLE
feat: add task categories and CSV export

### DIFF
--- a/export_to_csv.py
+++ b/export_to_csv.py
@@ -1,0 +1,49 @@
+import json
+import csv
+from integrated_pipeline import DatasetSample, assign_task_category
+
+
+def convert_to_csv(json_path="demo_output/network_config_qa_dataset.json", csv_path="demo_output/dataset_for_evaluation.csv"):
+    """최종 데이터셋 JSON을 평가용 CSV 파일로 변환합니다."""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        dataset = json.load(f)
+
+    header = ["입력 쿼리", "정답", "업무 분류", "참고 파일이름"]
+    rows = []
+
+    for split in ["train", "validation", "test"]:
+        for sample in dataset.get(split, []):
+            ds = DatasetSample(
+                id=sample.get("id", ""),
+                question=sample.get("question", ""),
+                context=sample.get("context", ""),
+                answer=str(sample.get("answer", "")),
+                answer_type=sample.get("answer_type", ""),
+                category=sample.get("category", ""),
+                complexity=sample.get("complexity", ""),
+                level=sample.get("level", 1),
+                persona=sample.get("persona"),
+                scenario=sample.get("scenario"),
+                source_files=sample.get("source_files"),
+                metadata=sample.get("metadata"),
+            )
+
+            task_category = ds.metadata.get("task_category") if ds.metadata and "task_category" in ds.metadata else assign_task_category(ds)
+            referenced_files_str = ", ".join(ds.source_files or [])
+            rows.append({
+                "입력 쿼리": ds.question,
+                "정답": ds.answer,
+                "업무 분류": task_category,
+                "참고 파일이름": referenced_files_str,
+            })
+
+    with open(csv_path, 'w', newline='', encoding='utf-8-sig') as f:
+        writer = csv.DictWriter(f, fieldnames=header)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"✅ CSV 파일 생성 완료: {csv_path}")
+
+
+if __name__ == "__main__":
+    convert_to_csv()

--- a/test_evidence_system.py
+++ b/test_evidence_system.py
@@ -63,9 +63,10 @@ def test_evidence_collection():
     
     # 계획 실행 및 답변 생성
     result = agent.execute_plan(test_question, test_plan)
-    
+
     print(f"\n🎯 **최종 답변:**")
-    print(result)
+    print(result.get("answer"))
+    print(f"\n📂 **참고 파일:** {result.get('source_files')}")
     print(f"\n📊 **수집된 증거:**")
     print(json.dumps(agent.evidence, indent=2, ensure_ascii=False))
     
@@ -81,9 +82,10 @@ def test_evidence_collection():
     print(f"계획: {test_plan2}")
     
     result2 = agent.execute_plan(test_question2, test_plan2)
-    
+
     print(f"\n🎯 **최종 답변:**")
-    print(result2)
+    print(result2.get("answer"))
+    print(f"\n📂 **참고 파일:** {result2.get('source_files')}")
     print(f"\n📊 **수집된 증거:**")
     print(json.dumps(agent.evidence, indent=2, ensure_ascii=False))
     
@@ -121,9 +123,10 @@ def test_evidence_collection():
     print("계획:", json.dumps(test_plan3, indent=2, ensure_ascii=False))
     
     result3 = agent.execute_plan(test_question3, test_plan3)
-    
+
     print(f"\n🎯 **최종 답변:**")
-    print(result3)
+    print(result3.get("answer"))
+    print(f"\n📂 **참고 파일:** {result3.get('source_files')}")
     print(f"\n📊 **수집된 증거:**")
     print(json.dumps(agent.evidence, indent=2, ensure_ascii=False))
 


### PR DESCRIPTION
## Summary
- tag each dataset sample with a task category during validation
- track referenced configuration files when executing reasoning plans and include them in samples
- return metric outputs with associated source files and provide a CSV export script

## Testing
- `pytest -q test_evaluation_system.py`
- `python test_evidence_system.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9ae6941108333938156b503b93a03