### PR TITLE
feat: extend metric coverage and scenario templates

### DIFF
--- a/generators/enhanced_llm_generator.py
+++ b/generators/enhanced_llm_generator.py
@@ -190,6 +190,29 @@ NOC 운영자 관점에서, 서비스 가용성과 관련된 복합적 상황 �
                 answer_type="long"
             ),
 
+            # What-if 시나리오 - NOC 운영자
+            QuestionTemplate(
+                complexity=QuestionComplexity.SCENARIO,
+                persona=PersonaType.NOC_OPERATOR,
+                scenario="링크 장애 시나리오 분석",
+                scenario_type=ScenarioType.FAILURE,
+                prompt_template="""
+NOC 운영자 관점에서, 네트워크의 특정 링크에 장애가 발생했다고 가정한 'What-if' 시나리오 질문을 생성하세요.
+질문의 답변은 반드시 **'대체 경로' 또는 '영향받는 서비스 이름'**과 같이 명확한 단일 값이어야 합니다.
+
+**[네트워크 토폴로지 정보]**
+- 주요 장비: CE1, CE2, sample7, sample8, sample9, sample10
+
+**[질문 생성 예시]**
+- "sample7과 sample8을 연결하는 링크가 다운될 경우, sample7에서 sample10으로 가는 트래픽의 새로운 경로는 무엇인가?"
+
+위 예시처럼 구체적인 장애 상황을 가정하고 그 결과(명확한 정답)를 묻는 질문과, 그 답을 찾기 위한 `reasoning_plan`을 생성해주세요.
+`reasoning_plan`에는 반드시 'find_alternative_path'와 같은 시뮬레이션 메트릭과 해당 메트릭에 필요한 파라미터(down_link 등)를 포함해야 합니다.
+""",
+                expected_metrics=["find_alternative_path"],
+                answer_type="short"
+            ),
+
             # 명확한 정답을 요구하는 분석형 - 트러블슈터
             QuestionTemplate(
                 complexity=QuestionComplexity.ANALYTICAL,

--- a/generators/rule_based_generator.py
+++ b/generators/rule_based_generator.py
@@ -44,6 +44,15 @@ ALLOWED_METRICS = {
         "vty_first_last_text","vty_login_mode_text","vty_password_secret_text","vty_transport_input_text",
         "system_users_detail_map","interface_mop_xenabled_bool"
     ],
+    "Security_Compliance": [
+        "ssh_acl_applied_check"
+    ],
+    "Routing_Policy_Inspection": [
+        "bgp_advertised_prefixes_list"
+    ],
+    "QoS_Verification": [
+        "qos_policer_applied_interfaces_list"
+    ],
 }
 
 def default_patterns(metric: str) -> str:
@@ -104,7 +113,10 @@ def default_patterns(metric: str) -> str:
         "vty_password_secret_text": "{host} 장비의 VTY password secret 값은?",
         "vty_transport_input_text": "{host} 장비에서 VTY의 transport input은?",
         "system_users_detail_map": "{host} 장비의 사용자 상세(UID/GID/HOME 등)는?",
-        "interface_mop_xenabled_bool": "{host} 장비에서 {if} 인터페이스의 MOP xenabled 설정은?"
+        "interface_mop_xenabled_bool": "{host} 장비에서 {if} 인터페이스의 MOP xenabled 설정은?",
+        "ssh_acl_applied_check": "{host} 장비에 SSH 접속 ACL이 적용되어 있는가?",
+        "bgp_advertised_prefixes_list": "{host} 장비가 BGP를 통해 외부로 광고하는 prefix 목록은?",
+        "qos_policer_applied_interfaces_list": "{host} 장비에서 QoS Policer가 적용된 인터페이스 목록은?"
     }
     return table.get(metric, f"{metric} 측정값은?")
 
@@ -244,7 +256,10 @@ METRIC_AGG = {
     "vty_password_secret_text":"text",
     "vty_transport_input_text":"text",
     "system_users_detail_map":"map",
-    "interface_mop_xenabled_bool":"boolean"
+    "interface_mop_xenabled_bool":"boolean",
+    "ssh_acl_applied_check":"boolean",
+    "bgp_advertised_prefixes_list":"set",
+    "qos_policer_applied_interfaces_list":"set"
 }
 
 CANDIDATES = {
@@ -313,7 +328,7 @@ def _mk(metric: str, agg: str, cat: str) -> Dict[str, Any]:
                   "system_hostname_text","system_mgmt_address_text","system_version_text","ios_config_register_text",
                   "logging_buffered_severity_text","http_server_enabled_bool","ip_forward_protocol_nd_bool","ip_cef_enabled_bool",
                   "vty_first_last_text","vty_login_mode_text","vty_password_secret_text","vty_transport_input_text",
-                  "system_users_detail_map"):
+                  "system_users_detail_map","ssh_acl_applied_check","bgp_advertised_prefixes_list","qos_policer_applied_interfaces_list"):
         scope={"type":"DEVICE","host":"{host}"}; placeholders=["host"]
     if metric == "interface_mop_xenabled_bool":
         scope={"type":"DEVICE_IF","host":"{host}","if":"{if}"}; placeholders=["host","if"]


### PR DESCRIPTION
## Summary
- add security, routing and QoS metric calculations and path simulation to BuilderCore
- support new static question metrics and categories in rule_based_generator
- introduce NOC operator what-if failure scenario template using `find_alternative_path`
- structure LLM and rule-based answers into `eval_targets` and explanatory text for flexible evaluation

## Testing
- `pytest` *(fails: import file mismatch for assemblers/test_assembler.py)*
- `PYTHONPATH=. pytest` *(fails: import file mismatch for assemblers/test_assembler.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1943f76083339ee7bbca28ab4ecf