### PR TITLE
feat: add command generation capability

### DIFF
--- a/command_agent.py
+++ b/command_agent.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+from typing import Dict, Any
+
+
+class CommandAgent:
+    """Rule-based CLI command generator.
+
+    Converts high level intents into concrete network CLI commands
+    using simple template substitution based on vendor type.
+    """
+
+    def __init__(self, network_facts: Dict[str, Any]):
+        devices = network_facts.get("devices", [])
+        self.vendor_map = {}
+        for d in devices:
+            host = (
+                d.get("system", {}).get("hostname")
+                or d.get("name")
+                or d.get("file")
+            )
+            vendor = (d.get("vendor") or d.get("os") or "").lower()
+            if host:
+                self.vendor_map[host] = vendor or "ios-xr"
+
+    def generate(self, intent: str, params: Dict[str, Any]) -> str:
+        vendor = self.vendor_map.get(params.get("host"), "ios-xr")
+        templates = self.command_templates().get(vendor, {})
+        template = templates.get(intent)
+        if not template:
+            raise ValueError(f"Unsupported intent '{intent}' for vendor '{vendor}'")
+        return template.format(**params)
+
+    @staticmethod
+    def command_templates() -> Dict[str, Dict[str, str]]:
+        """Return vendor specific command templates."""
+        templates = {
+            "ios-xr": {
+                # Level 1
+                "show_bgp_summary": "show bgp summary",
+                "show_ip_interface_brief": "show ip interface brief",
+                "show_ip_route_ospf": "show ip route ospf",
+                "show_processes_cpu": "show processes cpu sorted",
+                "show_l2vpn_vc": "show l2vpn atom vc",
+                "show_ip_ospf_neighbor": "show ip ospf neighbor",
+                "show_users": "show users",
+                "show_logging": "show logging",
+                "ssh_direct_access": "ssh {user}@{host}",
+                # Level 2
+                "set_static_route": "ip route {prefix} {mask} {next_hop}",
+                "set_bgp_routemap": (
+                    "router bgp {asn}\n neighbor {neighbor_ip} route-map {map_name} out"
+                ),
+                "set_interface_description": (
+                    "interface {interface}\n description {description}"
+                ),
+                "create_vrf_and_assign": (
+                    "vrf definition {vrf_name}\n exit\n interface {interface}\n vrf forwarding {vrf_name}"
+                ),
+                "set_ospf_cost": (
+                    "router ospf {process_id}\n interface {interface}\n ip ospf cost {cost}"
+                ),
+                "set_vty_acl": "line vty 0 4\n access-class {acl_name} in",
+                "set_hostname": "hostname {new_hostname}",
+                # Level 2.5 / 3
+                "ssh_proxy_jump": "ssh -J {user}@{jump_host} {user}@{destination_host}",
+                "ssh_multihop_jump": (
+                    "ssh -J {user}@{jump_host1},{user}@{jump_host2} {user}@{destination_host}"
+                ),
+                # Additional intents for diagnostic plans
+                "check_connectivity": "ping {destination}",
+                "show_bgp_neighbor_detail": "show bgp neighbor {neighbor_ip} detail",
+                "show_log_include": "show logging | include {keyword}",
+            }
+        }
+        # IOS devices share the same basic syntax for these commands
+        templates["ios"] = templates["ios-xr"]
+        return templates

--- a/generators/enhanced_llm_generator.py
+++ b/generators/enhanced_llm_generator.py
@@ -237,6 +237,40 @@ NOC 운영자 관점에서, 네트워크의 특정 링크에 장애가 발생했
                 expected_metrics=["ssh_present_bool", "aaa_present_bool", "bgp_neighbor_count"],
                 answer_type="short",
             ),
+            # 장애 진단 명령어 시퀀스 - 트러블슈터
+            QuestionTemplate(
+                complexity=QuestionComplexity.DIAGNOSTIC,
+                persona=PersonaType.TROUBLESHOOTER,
+                scenario="장애 진단 명령어 시퀀스",
+                scenario_type=ScenarioType.FAILURE,
+                prompt_template="""
+네트워크 트러블슈터 관점에서, 특정 장애 상황을 가정하고 문제를 진단하기 위해 순서대로 실행해야 할 CLI 명령어 3가지를 묻는 질문을 생성하세요.
+
+요구 사항:
+- 질문에는 실제 장비 이름과 장애 원인이 포함되어야 합니다.
+- reasoning_plan에는 각 단계별 intent와 params를 JSON 배열로 제공하세요.
+- intent는 CommandAgent에서 인식 가능한 명령어 이름을 사용합니다.
+""",
+                expected_metrics=[],
+                answer_type="long",
+            ),
+            # SSH 심화 시나리오 - 네트워크 엔지니어
+            QuestionTemplate(
+                complexity=QuestionComplexity.SCENARIO,
+                persona=PersonaType.NETWORK_ENGINEER,
+                scenario="SSH 심화 시나리오",
+                scenario_type=ScenarioType.NORMAL,
+                prompt_template="""
+네트워크 엔지니어 관점에서, 다단계 SSH 접속이 필요한 복잡한 운영 시나리오를 가정하고 목적지 장비에 도달하기 위한 SSH 명령어 시퀀스를 묻는 질문을 생성하세요.
+
+요구 사항:
+- 최소 두 개 이상의 점프 호스트를 포함해야 합니다.
+- reasoning_plan에는 각 단계별 intent와 params를 JSON 배열로 제공하세요.
+- intent는 ssh 관련 CommandAgent 명령어 이름을 사용합니다.
+""",
+                expected_metrics=[],
+                answer_type="long",
+            ),
         ]
     
     def generate_enhanced_questions(
@@ -380,12 +414,14 @@ NOC 운영자 관점에서, 네트워크의 특정 링크에 장애가 발생했
                                             "properties": {},
                                             "additionalProperties": True
                                         },
+                                        "intent": {"type": "string"},
+                                        "params": {"type": "object", "additionalProperties": True},
                                         "synthesis": {
                                             "type": "string",
                                             "enum": ["fetch", "compare", "summarize"]
                                         }
                                     },
-                                    "required": ["step", "description", "required_metric", "synthesis"],
+                                    "required": ["step"],
                                     "additionalProperties": False
                                 }
                             }


### PR DESCRIPTION
## Summary
- add CommandAgent for vendor-aware CLI command generation
- extend rule-based generator and pipeline to produce command questions
- introduce LLM templates for diagnostic command sequences and advanced SSH scenarios

## Testing
- `pytest assemblers/test_assembler.py test_evaluation_system.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab2974e6f883338b3b8f7afb832de6